### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Python CI
 
 on: [push]
 
+permissions:
+  contents: read
 #on:
 #  push:
 #    branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/KevinShindel/MachineLearning/security/code-scanning/1](https://github.com/KevinShindel/MachineLearning/security/code-scanning/1)

To fix this problem, a minimal `permissions` block should be defined at either the root of the workflow (applies to all jobs) or for the specific job. Since the workflow only runs local commands and checks out code, the only necessary permission is `contents: read` for reading (checking out) the repository. This should be added above the `jobs:` block in `.github/workflows/ci.yml`, ideally after the workflow name and trigger so it is global. No additional imports or changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
